### PR TITLE
Updates Rinn's experience total as well as Next Level Experience (900)

### DIFF
--- a/characters/rinn.md
+++ b/characters/rinn.md
@@ -7,7 +7,7 @@
 * **Background**: Former Child Thief (Urchin), now Priest in the Service of Tymora
 * **Alignment**: Chaotic Good
 * **Player Name**: Matt
-* **Experience Points**: 300 / 300
+* **Experience Points**: 420 / 900
 
 Str  | Dex  | Con  | Int  | Wis  | Cha
 --:  | --:  | --:  | --:  | --:  | --:


### PR DESCRIPTION
For those wanting to know, I usually like to have both my character's current XP total (420 in this case), and the value needed for the next level (e..g 900 xp for 3rd level).