### PR TITLE
Adds PDF reference to animal companions

### DIFF
--- a/errata/ranger-animal-companion-table.md
+++ b/errata/ranger-animal-companion-table.md
@@ -1,5 +1,7 @@
 # Ranger Animal Companion Table
 
+For full details on skills and such, take a look at the free [Basic DM Rules PDF](http://media.wizards.com/2014/downloads/dnd/DMBasicRulesv.0.3.pdf).
+
 ### Legend
 
 **PP**: Passive Perception; **DC**: Difficulty on Save; **Str**: Strength; **Con**: Constitution


### PR DESCRIPTION
Full details on animal companions can be found in the free Basic DM Rules PDF. I added a link to the animal companion table.

The critters are near the end. I've generally been able to find them by just searching for the name of the one I want.